### PR TITLE
Auditing을 이용하여 엔티티 속성 공통화하기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity5</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+            <version>${spring-security.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/project-shopmall.iml
+++ b/project-shopmall.iml
@@ -33,6 +33,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/java" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -145,8 +146,6 @@
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-security:2.7.4" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-aop:5.3.23" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.security:spring-security-config:5.7.3" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-core:5.7.3" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-crypto:5.7.3" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.security:spring-security-web:5.7.3" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-validation:2.7.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.tomcat.embed:tomcat-embed-el:9.0.65" level="project" />
@@ -154,5 +153,8 @@
     <orderEntry type="library" name="Maven: jakarta.validation:jakarta.validation-api:2.0.2" level="project" />
     <orderEntry type="library" name="Maven: org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.0.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.36" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.security:spring-security-test:5.7.3" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-core:5.7.3" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-crypto:5.7.3" level="project" />
   </component>
 </module>

--- a/src/main/java/com/shop/config/AuditorAwareImpl.java
+++ b/src/main/java/com/shop/config/AuditorAwareImpl.java
@@ -1,0 +1,27 @@
+package com.shop.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+/**
+ * 엔티티의 값이 생성되고 변경될 때,
+ * 현재 로그인한 사용자의 정보를 생성자와 수정자로 지정
+ * AuditorAware 인터페이스 구현
+ */
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String userId = "";
+        if (authentication != null) {
+            userId = authentication.getName();
+        }
+
+        return Optional.of(userId);
+    }
+}

--- a/src/main/java/com/shop/config/AuditorConfig.java
+++ b/src/main/java/com/shop/config/AuditorConfig.java
@@ -1,0 +1,16 @@
+package com.shop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditorConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/shop/entity/BaseEntity.java
+++ b/src/main/java/com/shop/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.shop.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
+}

--- a/src/main/java/com/shop/entity/BaseTimeEntity.java
+++ b/src/main/java/com/shop/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.shop.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter @Setter
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime regTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/shop/entity/Cart.java
+++ b/src/main/java/com/shop/entity/Cart.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @ToString
-public class Cart {
+public class Cart extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shop/entity/CartItem.java
+++ b/src/main/java/com/shop/entity/CartItem.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @ToString
-public class CartItem {
+public class CartItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shop/entity/Item.java
+++ b/src/main/java/com/shop/entity/Item.java
@@ -6,13 +6,12 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
 @Getter
 @ToString
-public class Item {
+public class Item extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,14 +36,6 @@ public class Item {
     @Setter
     @Enumerated(EnumType.STRING)
     private ItemSellStatus itemSellStatus; // 상품 판매 상태
-
-    private String createdBy; // 생성자
-
-    private LocalDateTime regTime; // 등록일
-
-    private String updatedBy; // 수정자
-
-    private LocalDateTime updateTime; // 수정일
 
     protected Item() {
     }

--- a/src/main/java/com/shop/entity/Member.java
+++ b/src/main/java/com/shop/entity/Member.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @ToString
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shop/entity/Order.java
+++ b/src/main/java/com/shop/entity/Order.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Getter
 @ToString
 @Table(name = "orders") // MySQL 예약어 `ORDER`와 클래스 이름이 겹쳐 테이블 이름을 orders 로 변경
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,9 +33,6 @@ public class Order {
 
     private LocalDateTime orderDate;
 
-    private LocalDateTime regTime;
-
-    private LocalDateTime updateTime;
 
     protected Order() {
     }

--- a/src/main/java/com/shop/entity/OrderItem.java
+++ b/src/main/java/com/shop/entity/OrderItem.java
@@ -4,12 +4,11 @@ import lombok.Getter;
 import lombok.ToString;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @ToString
-public class OrderItem {
+public class OrderItem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,10 +26,6 @@ public class OrderItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
-
-    private LocalDateTime regTime;
-
-    private LocalDateTime updateTime;
 
     protected OrderItem() {
     }

--- a/src/test/java/com/shop/entity/MemberTest.java
+++ b/src/test/java/com/shop/entity/MemberTest.java
@@ -1,0 +1,41 @@
+package com.shop.entity;
+
+import com.shop.constant.Role;
+import com.shop.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+class MemberTest {
+
+    @PersistenceContext
+    EntityManager em;
+    private final MemberRepository memberRepository;
+    public MemberTest(@Autowired MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Test
+    @DisplayName("Auditor 테스트")
+    @WithMockUser(username = "cheesecup", roles = "USER")
+    void auditorTest() {
+        Member member = Member.of("어디터", "auditor@auditor.com", "12341234", "어디터 집 주소", Role.USER);
+        Member savedMember = memberRepository.save(member);
+
+        em.flush();
+        em.clear();
+
+        Member findMember = memberRepository.findById(savedMember.getId()).orElseThrow(() -> new EntityNotFoundException());
+        System.out.println("createdBy = " + findMember.getCreatedBy());
+        System.out.println("regTime = " + findMember.getRegTime());
+    }
+}


### PR DESCRIPTION
JPA Auditing 을 활용하여 엔티티간의 공통 필드들 공통화.
(생성자, 수정자), (생성일, 수정일)을 각각 다른 클래스로 만들어 엔티티가 필요한 클래스를 상속하도록 함.

This closes #20 